### PR TITLE
Fix setup

### DIFF
--- a/obswebsocket/__init__.py
+++ b/obswebsocket/__init__.py
@@ -6,5 +6,3 @@ Python library to communicate with an obs-websocket server.
 """
 
 from .core import obsws
-
-__version__ = '0.3'

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,9 @@
 
 from __future__ import print_function
 
-from distutils.core import setup
+from setuptools import setup
 from setuptools.command.install import install
 
-from generate_classes import generate_classes
 from obswebsocket import __version__
 
 # Convert README from Markdown to reStructuredText
@@ -22,6 +21,7 @@ except:
 class CustomInstallCommand(install):
     def run(self):
         print("Generating API classes...")
+        from generate_classes import generate_classes
         generate_classes()
         install.run(self)
 
@@ -51,5 +51,6 @@ setup(
     'Programming Language :: Python :: 3',
   ],
 
+  setup_requires=['six'],
   install_requires=['websocket-client'],
 )

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,6 @@ from __future__ import print_function
 from setuptools import setup
 from setuptools.command.install import install
 
-from obswebsocket import __version__
-
 # Convert README from Markdown to reStructuredText
 description = open('README.md', 'r').read()
 try:
@@ -30,7 +28,7 @@ setup(
   packages = ['obswebsocket'],
   cmdclass = {'install': CustomInstallCommand},
   license = 'MIT',
-  version = __version__,
+  version = '0.3',
   description = 'Python library to communicate with an obs-websocket server.',
   long_description = description,
   author = 'Guillaume "Elektordi" Genty',


### PR DESCRIPTION
These changes will fix the current issues during installation, `setup.py` will install `six` before importing `generate_classes` and we're no longer importing the main package as we're specifying version directly in setup.py