### PR TITLE
Add delay to _wait_message to improve performance of requests

### DIFF
--- a/obswebsocket/core.py
+++ b/obswebsocket/core.py
@@ -180,6 +180,7 @@ class obsws:
 
     def _wait_message(self, message_id):
         timeout = time.time() + 60  # Timeout = 60s
+        time.sleep(0.05)
         while time.time() < timeout:
             if message_id in self.answers:
                 return self.answers.pop(message_id)


### PR DESCRIPTION
This adds a 50ms delay before the loop in _wait_message in order to increase the odds that a response to the request has been received before the first check.

The result is to cut request time in half for most applications.