### PR TITLE
Fix(core): Added the timout to the connection of the actual WebSocket

### DIFF
--- a/obswebsocket/core.py
+++ b/obswebsocket/core.py
@@ -81,7 +81,7 @@ class obsws:
             self.ws = websocket.WebSocket()
             url = "ws://{}:{}".format(self.host, self.port)
             LOG.info("Connecting to %s..." % (url))
-            self.ws.connect(url)
+            self.ws.connect(url, timeout=self.timeout)
             LOG.info("Connected!")
             if self.legacy:
                 self._auth_legacy()


### PR DESCRIPTION
When using some IP Addresses (Example: 192.0.0.1) it would get stuck when calling `connect()` and not raise any error.
This is fixed by using the passed timeout to also apply when connecting by passing it into the actual WebSocket